### PR TITLE
chore: bump version to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-08-11
+
+### Added
+- **Automatic Payments example**: two-step recurring flow ([#386](https://github.com/mercadopago/sdk-java/pull/386))
+- **Order model**: reuse `client/common` types in `OrderPayerRequest`, add `country` to `AddressRequest`, restore `currency` field position in `OrderCreateRequest` ([#386](https://github.com/mercadopago/sdk-java/pull/386))
+
+### Fixed
+- **Stored credential**: rename `prevTransactionRef` to `previousTransactionReference` ([#386](https://github.com/mercadopago/sdk-java/pull/386))
+- Deprecated `Matchers` replaced with `ArgumentMatchers` in unit tests ([#386](https://github.com/mercadopago/sdk-java/pull/386))
+
+### CI
+- Standardize CI/CD workflows ([#399](https://github.com/mercadopago/sdk-java/pull/399))
+- Add mock-based unit tests ([#399](https://github.com/mercadopago/sdk-java/pull/399))
+- Skip lombok-maven-plugin delombok in CI to support Java 17 and 21 ([#399](https://github.com/mercadopago/sdk-java/pull/399))
+
 ## [3.4.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>3.4.0</version>
+  <version>3.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -35,7 +35,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
  */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "3.4.0";
+  public static final String CURRENT_VERSION = "3.5.0";
 
   /** Internal MercadoPago product identifier sent in every API request for analytics. */
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";


### PR DESCRIPTION
## Summary
- Bump version from \`3.4.0\` to \`3.5.0\`
- Update \`pom.xml\`, \`MercadoPagoConfig.java\`, \`README.md\`, \`CHANGELOG.md\`

## Changelog entry
### Added
- Automatic Payments example: two-step recurring flow ([#386](https://github.com/mercadopago/sdk-java/pull/386))
- Order model: reuse \`client/common\` types in \`OrderPayerRequest\`, add \`country\` to \`AddressRequest\`, restore \`currency\` field position in \`OrderCreateRequest\` ([#386](https://github.com/mercadopago/sdk-java/pull/386))
### Fixed
- Stored credential: rename \`prevTransactionRef\` to \`previousTransactionReference\` ([#386](https://github.com/mercadopago/sdk-java/pull/386))
- Deprecated \`Matchers\` replaced with \`ArgumentMatchers\` in unit tests ([#386](https://github.com/mercadopago/sdk-java/pull/386))
### CI
- Standardize CI/CD workflows ([#399](https://github.com/mercadopago/sdk-java/pull/399))
- Add mock-based unit tests ([#399](https://github.com/mercadopago/sdk-java/pull/399))
- Skip lombok-maven-plugin delombok in CI to support Java 17 and 21 ([#399](https://github.com/mercadopago/sdk-java/pull/399))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files