### PR TITLE
fix: replace lombok-maven-plugin with exec-maven-plugin for delombok

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -34,4 +34,4 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         run: |
-          mvn --no-transfer-progress --batch-mode clean deploy -Dlombok.delombok.skip=true
+          mvn --no-transfer-progress --batch-mode clean deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
           distribution: "temurin"
 
       - name: Compile
-        run: mvn compile --no-transfer-progress -Dlombok.delombok.skip=true
+        run: mvn compile --no-transfer-progress
 
       - name: Run unit tests
-        run: mvn test --no-transfer-progress -Dtest="**/*Test" -DfailIfNoTests=false -Dlombok.delombok.skip=true
+        run: mvn test --no-transfer-progress -Dtest="**/*Test" -DfailIfNoTests=false
+
 
       - name: Dependency review
         if: github.event_name == 'pull_request'

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
                 <configuration>
                     <source>1.8</source>
                     <doclint>none</doclint>
+                    <sourcepath>${project.build.directory}/delombok</sourcepath>
                     <outputDirectory>${project.basedir}/docs</outputDirectory>
                 </configuration>
                 <executions>
@@ -163,20 +164,27 @@
             </plugin>
 
             <plugin>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.20.0</version>
-                <configuration>
-                    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
-                    <outputDirectory>${project.build.directory}/delombok</outputDirectory>
-                    <addOutputDirectory>false</addOutputDirectory>
-                </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
+                        <id>delombok</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <goal>delombok</goal>
+                            <goal>exec</goal>
                         </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-jar</argument>
+                                <argument>${settings.localRepository}/org/projectlombok/lombok/${lombok.version}/lombok-${lombok.version}.jar</argument>
+                                <argument>delombok</argument>
+                                <argument>${project.basedir}/src/main/java</argument>
+                                <argument>-d</argument>
+                                <argument>${project.build.directory}/delombok</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -193,6 +201,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <lombok.version>1.18.46</lombok.version>
     </properties>
 
     <dependencies>
@@ -260,7 +269,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.46</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
lombok-maven-plugin:1.18.20.0 is incompatible with lombok:1.18.46, producing an empty target/delombok. maven-javadoc-plugin 3.12.0 then reports "No Javadoc in project" regardless of sourcepath config, causing Maven Central to reject the deployment.

This commit:
- Replaces lombok-maven-plugin with exec-maven-plugin that invokes `java -jar lombok-1.18.46.jar delombok` directly, ensuring version compatibility and support for Java 11/17/21
- Extracts lombok.version as a property to keep version in sync
- Restores sourcepath pointing to target/delombok (now reliably populated)
- Removes -Dlombok.delombok.skip=true from CI and CD workflows since the flag only applied to the now-removed lombok-maven-plugin

## Cambios realizados para el feature:
 * item 1

## Cambios generales
 * item 1
 
## Issues cerrados
 * Closes #XX
 

## Checklist validación PR:

- [ ] Título y descripción clara del PR
- [ ] Tests de mi funcionalidad 
- [ ] Documentación de mi funcionalidad
- [ ] Tests ejecutados y pasados
- [ ] Branch Coverage >= 80%
