### PR TITLE
fix: pass project classpath to lombok delombok to resolve types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,25 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>build-classpath</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <outputProperty>project.compile.classpath</outputProperty>
+                            <includeScope>compile</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>3.2.8</version>
                 <executions>
@@ -180,6 +199,8 @@
                                 <argument>-jar</argument>
                                 <argument>${settings.localRepository}/org/projectlombok/lombok/${lombok.version}/lombok-${lombok.version}.jar</argument>
                                 <argument>delombok</argument>
+                                <argument>--classpath</argument>
+                                <argument>${project.compile.classpath}</argument>
                                 <argument>${project.basedir}/src/main/java</argument>
                                 <argument>-d</argument>
                                 <argument>${project.build.directory}/delombok</argument>


### PR DESCRIPTION
Without --classpath, lombok delombok cannot resolve external types (org.apache.http, com.google.gson, etc.) and prints errors for every unresolved symbol, even though the source transformation still works.

Adds maven-dependency-plugin:build-classpath in the initialize phase to capture the compile-scope classpath into ${project.compile.classpath}, then passes it to the delombok invocation via --classpath. This gives the lombok tool full type resolution, eliminating the false errors.

## Cambios realizados para el feature:
 * item 1

## Cambios generales
 * item 1
 
## Issues cerrados
 * Closes #XX
 

## Checklist validación PR:

- [ ] Título y descripción clara del PR
- [ ] Tests de mi funcionalidad 
- [ ] Documentación de mi funcionalidad
- [ ] Tests ejecutados y pasados
- [ ] Branch Coverage >= 80%
